### PR TITLE
Correção da assinatura do método load para utilizar o tipo I ao invés de Object. Isto causava nameClash ao sobrescrever o método nas classes que herdavam da mesma.

### DIFF
--- a/impl/extension/jpa/src/main/java/br/gov/frameworkdemoiselle/template/JPACrud.java
+++ b/impl/extension/jpa/src/main/java/br/gov/frameworkdemoiselle/template/JPACrud.java
@@ -154,7 +154,7 @@ public class JPACrud<T, I> implements Crud<T, I> {
 	}
 
 	@Override
-	public T load(final Object id) {
+	public T load(final I id) {
 		return getEntityManager().find(getBeanClass(), id);
 	}
 


### PR DESCRIPTION
...ate/JPACrud.java
