### PR TITLE
simplificação do processo de adição de Faces Messages internacionalizáveis baseadas em ResourceBundle

### DIFF
--- a/impl/extension/jsf/src/main/java/br/gov/frameworkdemoiselle/util/Faces.java
+++ b/impl/extension/jsf/src/main/java/br/gov/frameworkdemoiselle/util/Faces.java
@@ -185,4 +185,8 @@ public class Faces {
 		addMessage(new DefaultMessage(Beans.getReference(ResourceBundle.class).getString(bundleKey, params), type));
 	}
 
+	public static <T> T getManagedProperty(String expression, Class<T> expectedType) {
+		FacesContext context = getFacesContext();
+		return (T) context.getApplication().evaluateExpressionGet(context, expression, expectedType);
+	}
 }


### PR DESCRIPTION
O objetivo deste commit é simplificar o acesso a "Faces Messages internacionalizadas" integrando-se a classe Faces com ResourceBundle;

Atualmente requer-se algo como:
    inject private ResourceBundle bundle;
    //...
    Faces.addMessage(new DefaultMessage(bundle.getString("some-bundle-key")));

A alteração proposta irá simplificar para:
    Faces.addI18nMessage("some-bundle-key");

Ps: utilizar a DefaultMessage atende a grande maioria dos casos de uso de Faces Messages. E nada impede de realizar o acesso a Faces Message da forma atual caso não deseje-se usar a DefaultMessage via addI18nMessage;
