### PR TITLE
README com markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ qualquer pessoa que se interessasse.
 
 O framework Demoiselle usa a mesma filosofia do “Pai da Aviação”,
 tendo sido disponibilizado como software livre em abril de 2009, sob a
-licença livre LGPL version 3. Mais informações no [portal](www.frameworkdemoiselle.gov.br)
+licença livre LGPL version 3. Mais informações no [portal](www.frameworkdemoiselle.gov.br).
 
 
 Links úteis
@@ -27,25 +27,25 @@ Links úteis
 
 * [Portal](http://frameworkdemoiselle.gov.br): Central de acesso as informações do Demoiselle
 * [Documentação](http://demoiselle.sf.net/docs): Aprenda sobre o Demoiselle seguindo os vários módulos
-* [Fórum]:(http://forum.frameworkdemoiselle.gov.br) Fóruns de discussão
+* [Fórum](http://forum.frameworkdemoiselle.gov.br): Fóruns de discussão
 * [Tracker](http://tracker.frameworkdemoiselle.gov.br): Submissão/acompanhamento de Bugs, Improvements e New Features
-* [Lista de discussão]: Comunicação e troca de experiências entre os usuários do projeto.
+* [Lista de discussão](https://lists.sourceforge.net/lists/listinfo/demoiselle-users): Comunicação e troca de experiências entre os usuários do projeto.
 
 
 Repositório Maven
 -----------
 
     <repository>
-   <id>demoiselle.sourceforge.net-release</id>
-<url>http://demoiselle.sourceforge.net/repository/release</url>
-</repository>
+        <id>demoiselle.sourceforge.net-release</id>
+        <url>http://demoiselle.sourceforge.net/repository/release</url>
+    </repository>
 
 
 Contribuindo
 ------------
 
 1. Faça o seu fork.
-2. Crie o seu branch(ramo) - (`git checkout -b meu_framework`)
+2. Crie o seu branch (ramo) - (`git checkout -b meu_framework`)
 3. Commit seu código (`git commit -am "Explicando o motivo/objetivo"`)
 4. Agora execute o Push para o branch (`git push origin meu_framework`)
 5. Crie um caso no [mantis][1] com o link para o seu branch


### PR DESCRIPTION
Notei que o README do projeto utiliza markdown, mas não possui a extensão .md, então o GitHub renderiza como texto plano. Fiz um fork simples para renomear o arquivo e corrigir alguns probleminhas de sintaxe no arquivo. Acho que melhorou a cara do projeto para quem chega nesta página do projeto.
