### PR TITLE
Modifica getRequest ao obter parâmetros.

### DIFF
--- a/impl/extension/jsf/src/main/java/br/gov/frameworkdemoiselle/internal/implementation/ParameterImpl.java
+++ b/impl/extension/jsf/src/main/java/br/gov/frameworkdemoiselle/internal/implementation/ParameterImpl.java
@@ -80,7 +80,7 @@ public class ParameterImpl<T extends Serializable> implements Parameter<T>, Seri
 	}
 
 	private HttpServletRequest getRequest() {
-		return Beans.getReference(HttpServletRequest.class);
+		return (HttpServletRequest)FacesContext.getCurrentInstance().getExternalContext().getRequest();
 	}
 
 	@Inject


### PR DESCRIPTION
Corrige o bug #FWK-78. Essa mudança foi necessária para o Demoiselle voltar a
obter os parâmetros de requisição quando o PrettyURL ou o Rewrite estão sendo
usados.
