### PR TITLE
Conserta NPE ao tentar invalidar a sessão após logout.

### DIFF
--- a/impl/extension/jsf/src/main/java/br/gov/frameworkdemoiselle/internal/implementation/SecurityObserver.java
+++ b/impl/extension/jsf/src/main/java/br/gov/frameworkdemoiselle/internal/implementation/SecurityObserver.java
@@ -161,7 +161,8 @@ public class SecurityObserver implements Serializable {
 
 		} finally {
 			try {
-				Beans.getReference(HttpSession.class).invalidate();
+				HttpSession session = (HttpSession)FacesContext.getCurrentInstance().getExternalContext().getSession(false);
+				session.invalidate();
 			} catch (IllegalStateException e) {
 				logger.debug("Esta sessão já foi invalidada.");
 			}


### PR DESCRIPTION
O problema ocorre quando se está usando [rewrite](http://ocpsoft.org/rewrite/) ou [prettyfaces](http://ocpsoft.org/prettyfaces/). Nesse caso, ao realizar logout na aplicação, é lançada uma NullPointerException (NPE). O problema é que a chamada Beans.getReference(HttpSession.class) retorna null. Este patch tenta obter a sessão através da classe FacesContext.
