### PR TITLE
Ajuste para considerar uma hierarquia de qualquer tamanho para classes que herdam de DelegateCrud

### DIFF
--- a/impl/core/src/main/java/br/gov/frameworkdemoiselle/util/Reflections.java
+++ b/impl/core/src/main/java/br/gov/frameworkdemoiselle/util/Reflections.java
@@ -58,7 +58,7 @@ public final class Reflections {
 		try {
 			paramType = (ParameterizedType) type;
 		} catch (ClassCastException cause) {
-			paramType = (ParameterizedType) ((Class<T>) type).getGenericSuperclass();
+			return getGenericTypeArgument((Class<T>) type, idx);
 		}
 
 		return (Class<T>) paramType.getActualTypeArguments()[idx];

--- a/impl/core/src/test/java/br/gov/frameworkdemoiselle/util/ReflectionsTest.java
+++ b/impl/core/src/test/java/br/gov/frameworkdemoiselle/util/ReflectionsTest.java
@@ -56,6 +56,12 @@ public class ReflectionsTest {
 		assertEquals(Long.class, Reflections.getGenericTypeArgument(members[0], 0));
 		assertEquals(String.class, Reflections.getGenericTypeArgument(members[1], 0));
 	}
+
+	@Test
+	public void testGetGenericTypeArgumentClassMultipleChildren() {
+		assertEquals(Long.class, Reflections.getGenericTypeArgument(OtherClass3.class, 0));
+		assertEquals(String.class, Reflections.getGenericTypeArgument(OtherClass3.class, 1));
+	}
 }
 
 class SomeClass<T, I> {
@@ -70,4 +76,12 @@ class OtherClass extends SomeClass<Long, String> {
 	public Class<Long> number;
 
 	public Class<String> text;
+}
+
+class OtherClass2 extends OtherClass {
+
+}
+
+class OtherClass3 extends OtherClass2 {
+
 }


### PR DESCRIPTION
O problema foi observado ao utilizar o @Spy (mockito):

```
   @Spy
@Inject
private SomeBC someBC;

@Before
public void before() {
    MockitoAnnotations.initMocks(this);
    someBC.deleteAll();
}
```

java.lang.ClassCastException: java.lang.Class cannot be cast to java.lang.reflect.ParameterizedType
    at br.gov.frameworkdemoiselle.util.Reflections.getGenericTypeArgument(Reflections.java:61)
    at br.gov.frameworkdemoiselle.template.DelegateCrud.getDelegateClass(DelegateCrud.java:126)
