### PR TITLE
Checar se o recurso é uma instância da classe AbstractREST.

### DIFF
--- a/demoiselle-crud/src/main/java/org/demoiselle/jee/crud/CrudFilter.java
+++ b/demoiselle-crud/src/main/java/org/demoiselle/jee/crud/CrudFilter.java
@@ -154,7 +154,7 @@ public class CrudFilter implements ContainerResponseFilter, ContainerRequestFilt
      */
     private Boolean isRequestForCrud() {
         if (resourceInfo.getResourceClass().getSuperclass() != null
-                && resourceInfo.getResourceClass().getSuperclass().equals(AbstractREST.class)
+                && resourceInfo.getResourceClass().isInstance(AbstractREST.class)
                 && resourceInfo.getResourceMethod().isAnnotationPresent(GET.class)) {
             return Boolean.TRUE;
         }


### PR DESCRIPTION
Isso permite criar classes especializadas que herdam de AbstractREST, mas que continuem usufruindo das suas funcionalidades.