### PR TITLE
Correção da cláusula SET do update parcial

### DIFF
--- a/demoiselle-crud/src/main/java/org/demoiselle/jee/crud/AbstractDAO.java
+++ b/demoiselle-crud/src/main/java/org/demoiselle/jee/crud/AbstractDAO.java
@@ -91,6 +91,10 @@ public abstract class AbstractDAO<T, I> implements Crud<T, I> {
                 final Object value = field.get(entity);
                 //
                 if (value != null) {
+                    if (!params.isEmpty()) {
+                		sb.append(", ");
+                	}
+                    //
                 	sb.append(name).append(" = :").append(name);
                 	params.put(name, value);
                 }


### PR DESCRIPTION
O código esqueceu de contemplar a vírgula para separar múltiplos campos na cláusula SET do update.