### PR TITLE
Ignorar colunas updatable=false no update parcial.

### DIFF
--- a/demoiselle-crud/src/main/java/org/demoiselle/jee/crud/CrudUtilHelper.java
+++ b/demoiselle-crud/src/main/java/org/demoiselle/jee/crud/CrudUtilHelper.java
@@ -35,7 +35,7 @@ public class CrudUtilHelper {
      * @return Class used on {@literal AbstractREST<TargetClass, I>}
      */
     public static Class<?> getTargetClass(Class<?> targetClass) {
-        if (targetClass.getSuperclass().equals(AbstractREST.class)) {
+        if (AbstractREST.class.isAssignableFrom(targetClass)) {
             Class<?> type = (Class<?>) ((ParameterizedType) targetClass.getGenericSuperclass()).getActualTypeArguments()[0];
             return type;
         }


### PR DESCRIPTION
Mais uma melhoria no método mergeHalf() for implementada, a fim de evitar que colunas marcadas com updatable=false sejam incluídas na cláusula SET do update.

Também foi contemplado alterações em colunas de relacionamento many-to-one.