### PR TITLE
Limitando o número de stores armazenadas no ViewScope

### DIFF
--- a/impl/extension/jsf/src/main/java/br/gov/frameworkdemoiselle/internal/context/FacesViewBeanStore.java
+++ b/impl/extension/jsf/src/main/java/br/gov/frameworkdemoiselle/internal/context/FacesViewBeanStore.java
@@ -120,6 +120,21 @@ public class FacesViewBeanStore implements Serializable {
 		}
 	}
 
+	/**
+	 * Destroys all view scoped beans and the associated {@link BeanStore} for the specified viewId.
+	 * 
+	 * @param context
+	 *            ViewContext managing the view scoped beans
+	 * @param viewId
+	 *            ID of the current view
+	 */
+	public void destroyStore(final AbstractCustomContext context, Long viewId) {
+		FacesViewData viewData = viewStore.remove(viewId);
+		if (viewData != null) {
+			destroyStore(context, viewData);
+		}
+	}
+
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	private void destroyStore(final AbstractCustomContext context, FacesViewData data) {
 		for (String id : data.store) {

--- a/impl/extension/jsf/src/main/java/br/gov/frameworkdemoiselle/internal/context/FacesViewBeanStore.java
+++ b/impl/extension/jsf/src/main/java/br/gov/frameworkdemoiselle/internal/context/FacesViewBeanStore.java
@@ -65,8 +65,6 @@ public class FacesViewBeanStore implements Serializable {
 	 * @param context
 	 *            Reference to the {@link ViewContext} class managing the view scope
 	 * @return The {@link BeanStore} that stores view scoped beans for this view ID
-	 * @throws IllegalStateException
-	 *             if the view associated with the requested view ID has expired
 	 */
 	public BeanStore getStoreForView(Long viewId, AbstractCustomContext context) {
 		BeanStore store;

--- a/impl/extension/jsf/src/main/java/br/gov/frameworkdemoiselle/internal/context/FacesViewBeanStore.java
+++ b/impl/extension/jsf/src/main/java/br/gov/frameworkdemoiselle/internal/context/FacesViewBeanStore.java
@@ -1,14 +1,21 @@
 package br.gov.frameworkdemoiselle.internal.context;
 
 import java.io.Serializable;
+import java.text.MessageFormat;
+import java.util.Collections;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Map.Entry;
-import java.util.concurrent.ConcurrentHashMap;
 
+import javax.enterprise.context.spi.Context;
 import javax.enterprise.context.spi.Contextual;
 import javax.enterprise.context.spi.CreationalContext;
 
 import br.gov.frameworkdemoiselle.context.ViewContext;
+import br.gov.frameworkdemoiselle.lifecycle.ViewScoped;
+import br.gov.frameworkdemoiselle.util.Beans;
+import br.gov.frameworkdemoiselle.util.Faces;
 import br.gov.frameworkdemoiselle.util.ResourceBundle;
 
 /**
@@ -21,7 +28,33 @@ public class FacesViewBeanStore implements Serializable {
 
 	private static final long serialVersionUID = -8265458933971929432L;
 
-	private final ConcurrentHashMap<Long, FacesViewData> viewStore = new ConcurrentHashMap<Long, FacesViewBeanStore.FacesViewData>();
+	/**
+	 * Demoiselle specific context parameter name of maximum active view scopes in
+	 * session.
+	 */
+	public static final String PARAM_NAME_MAX_ACTIVE_VIEW_SCOPES = "br.gov.frameworkdemoiselle.MAX_ACTIVE_VIEW_SCOPES";
+
+	/**
+	 * Mojarra specific context parameter name of maximum number of logical views in
+	 * session.
+	 */
+	public static final String PARAM_NAME_MOJARRA_NUMBER_OF_VIEWS = "com.sun.faces.numberOfLogicalViews";
+
+	/**
+	 * MyFaces specific context parameter name of maximum number of views in
+	 * session.
+	 */
+	public static final String PARAM_NAME_MYFACES_NUMBER_OF_VIEWS = "org.apache.myfaces.NUMBER_OF_VIEWS_IN_SESSION";
+
+	/** Default value of maximum active view scopes in session. */
+	public static final int DEFAULT_MAX_ACTIVE_VIEW_SCOPES = 20; // Mojarra's default is 15 and MyFaces' default is 20.
+
+	private static final String[] PARAM_NAMES_MAX_ACTIVE_VIEW_SCOPES = { PARAM_NAME_MAX_ACTIVE_VIEW_SCOPES,
+			PARAM_NAME_MOJARRA_NUMBER_OF_VIEWS, PARAM_NAME_MYFACES_NUMBER_OF_VIEWS };
+
+	private static volatile Integer maxActiveViewScopes;
+
+	private final Map<Long, FacesViewData> viewStore = Collections.synchronizedMap(new LRUViewStoreMap());
 
 	private long maxInactiveTimeInSeconds;
 
@@ -51,8 +84,7 @@ public class FacesViewBeanStore implements Serializable {
 				data.store = store;
 				viewStore.put(viewId, data);
 			} else if (data.isExpired(maxInactiveTimeInSeconds)) {
-				throw new IllegalStateException(ResourceBundle.getBundle("demoiselle-jsf-bundle").getString(
-						"view-expired"));
+				throw new IllegalStateException(getMessageBundle().getString("view-expired"));
 			}
 		}
 
@@ -76,28 +108,82 @@ public class FacesViewBeanStore implements Serializable {
 	 * @param onlyExpired
 	 *            Only destroy beans if the underlying view has expired
 	 */
-	@SuppressWarnings({ "rawtypes", "unchecked" })
 	public void destroyStoresInSession(final AbstractCustomContext context, final boolean onlyExpired) {
 		for (Iterator<Entry<Long, FacesViewData>> it = viewStore.entrySet().iterator(); it.hasNext();) {
 			Entry<Long, FacesViewData> currentEntry = it.next();
 			FacesViewData data = currentEntry.getValue();
 
-			if (data != null && data.store != null) {
-				if (!onlyExpired || data.isExpired(maxInactiveTimeInSeconds)) {
-					for (String id : data.store) {
-						Contextual contextual = context.getContextualStore().getContextual(id);
-						Object instance = data.store.getInstance(id);
-						CreationalContext creationalContext = data.store.getCreationalContext(id);
+			if (!onlyExpired || data.isExpired(maxInactiveTimeInSeconds)) {
+				destroyStore(context, data);
+				it.remove();
+			}
+		}
+	}
 
-						if (contextual != null && instance != null) {
-							contextual.destroy(instance, creationalContext);
-						}
-					}
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	private void destroyStore(final AbstractCustomContext context, FacesViewData data) {
+		for (String id : data.store) {
+			Contextual contextual = context.getContextualStore().getContextual(id);
+			Object instance = data.store.getInstance(id);
+			CreationalContext creationalContext = data.store.getCreationalContext(id);
 
-					data.store.clear();
-					it.remove();
+			if (contextual != null && instance != null) {
+				contextual.destroy(instance, creationalContext);
+			}
+		}
+
+		data.store.clear();
+	}
+
+	/**
+	 * Returns the max active view scopes depending on available context params.
+	 * This will be calculated lazily once and re-returned everytime; the faces
+	 * context is namely not available during class' initialization/construction,
+	 * but only during a post construct.<br>
+	 * (from OmniFaces implementation)
+	 */
+	private static int getMaxActiveViewScopes() {
+		if (maxActiveViewScopes != null) {
+			return maxActiveViewScopes;
+		}
+
+		for (String name : PARAM_NAMES_MAX_ACTIVE_VIEW_SCOPES) {
+			String value = Faces.getInitParameter(name);
+
+			if (value != null) {
+				try {
+					maxActiveViewScopes = Integer.valueOf(value);
+					return maxActiveViewScopes;
+				} catch (NumberFormatException e) {
+					String message = getMessageBundle().getString("max-active-view-scopes-param-invalid");
+					throw new IllegalArgumentException(MessageFormat.format(message, name, value), e);
 				}
 			}
+		}
+
+		maxActiveViewScopes = DEFAULT_MAX_ACTIVE_VIEW_SCOPES;
+		return maxActiveViewScopes;
+	}
+
+	private static java.util.ResourceBundle getMessageBundle() {
+		return ResourceBundle.getBundle("demoiselle-jsf-bundle");
+	}
+
+	private final class LRUViewStoreMap extends LinkedHashMap<Long, FacesViewBeanStore.FacesViewData> {
+
+		private static final long serialVersionUID = -2520661683192850878L;
+
+		protected boolean removeEldestEntry(Map.Entry<Long, FacesViewData> eldest) {
+			if (size() > getMaxActiveViewScopes()) {
+
+				final Context context = Beans.getBeanManager().getContext(ViewScoped.class);
+
+				if (context instanceof AbstractCustomContext) {
+					destroyStore((AbstractCustomContext) context, eldest.getValue());
+				}
+				return true;
+			}
+			return false;
 		}
 	}
 

--- a/impl/extension/jsf/src/main/java/br/gov/frameworkdemoiselle/internal/context/FacesViewContextEventListener.java
+++ b/impl/extension/jsf/src/main/java/br/gov/frameworkdemoiselle/internal/context/FacesViewContextEventListener.java
@@ -1,0 +1,34 @@
+package br.gov.frameworkdemoiselle.internal.context;
+
+import javax.enterprise.context.spi.Context;
+import javax.faces.component.UIViewRoot;
+import javax.faces.event.AbortProcessingException;
+import javax.faces.event.PreDestroyViewMapEvent;
+import javax.faces.event.SystemEvent;
+import javax.faces.event.ViewMapListener;
+
+import br.gov.frameworkdemoiselle.lifecycle.ViewScoped;
+import br.gov.frameworkdemoiselle.util.Beans;
+
+/**
+ * Listener for JSF view scope destroy events so that view scope context can be notified.
+ */
+public class FacesViewContextEventListener implements ViewMapListener {
+
+	@Override
+	public void processEvent(SystemEvent event) throws AbortProcessingException {
+		if (event instanceof PreDestroyViewMapEvent) {
+			final Context context = Beans.getBeanManager().getContext(ViewScoped.class);
+
+			if (context instanceof FacesViewContextImpl) {
+				((FacesViewContextImpl) context).clearView();
+			}
+		}
+	}
+
+	@Override
+	public boolean isListenerForSource(Object source) {
+		return (source instanceof UIViewRoot);
+	}
+
+}

--- a/impl/extension/jsf/src/main/java/br/gov/frameworkdemoiselle/internal/context/FacesViewContextEventListener.java
+++ b/impl/extension/jsf/src/main/java/br/gov/frameworkdemoiselle/internal/context/FacesViewContextEventListener.java
@@ -1,3 +1,39 @@
+/*
+ * Demoiselle Framework
+ * Copyright (C) 2010 SERPRO
+ * ----------------------------------------------------------------------------
+ * This file is part of Demoiselle Framework.
+ * 
+ * Demoiselle Framework is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License version 3
+ * as published by the Free Software Foundation.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License version 3
+ * along with this program; if not,  see <http://www.gnu.org/licenses/>
+ * or write to the Free Software Foundation, Inc., 51 Franklin Street,
+ * Fifth Floor, Boston, MA  02110-1301, USA.
+ * ----------------------------------------------------------------------------
+ * Este arquivo é parte do Framework Demoiselle.
+ * 
+ * O Framework Demoiselle é um software livre; você pode redistribuí-lo e/ou
+ * modificá-lo dentro dos termos da GNU LGPL versão 3 como publicada pela Fundação
+ * do Software Livre (FSF).
+ * 
+ * Este programa é distribuído na esperança que possa ser útil, mas SEM NENHUMA
+ * GARANTIA; sem uma garantia implícita de ADEQUAÇÃO a qualquer MERCADO ou
+ * APLICAÇÃO EM PARTICULAR. Veja a Licença Pública Geral GNU/LGPL em português
+ * para maiores detalhes.
+ * 
+ * Você deve ter recebido uma cópia da GNU LGPL versão 3, sob o título
+ * "LICENCA.txt", junto com esse programa. Se não, acesse <http://www.gnu.org/licenses/>
+ * ou escreva para a Fundação do Software Livre (FSF) Inc.,
+ * 51 Franklin St, Fifth Floor, Boston, MA 02111-1301, USA.
+ */
 package br.gov.frameworkdemoiselle.internal.context;
 
 import javax.enterprise.context.spi.Context;

--- a/impl/extension/jsf/src/main/java/br/gov/frameworkdemoiselle/internal/context/FacesViewContextImpl.java
+++ b/impl/extension/jsf/src/main/java/br/gov/frameworkdemoiselle/internal/context/FacesViewContextImpl.java
@@ -129,6 +129,19 @@ public class FacesViewContextImpl extends AbstractCustomContext implements ViewC
 		return currentViewStore.getStoreForView(viewId, this);
 	}
 
+	/**
+	 * Called by the {@link FacesViewContextEventListener} on the PreDestroyViewMapEvent event so that we can destroy
+	 * all beans associated with the view that's been cleared.
+	 */
+	public void clearView() {
+		FacesViewBeanStore beanStore = viewStoreInSession.get(getSessionId());
+		Long viewId = (Long) Faces.getViewMap().get(FACES_KEY);
+		if (viewId == null || beanStore == null) {
+			return;
+		}
+		beanStore.destroyStore(this, viewId);
+	}
+
 	/*
 	 * Called before the session is invalidated for that user.
 	 * Destroys all view scoped beans stored on that session.

--- a/impl/extension/jsf/src/main/java/br/gov/frameworkdemoiselle/util/Faces.java
+++ b/impl/extension/jsf/src/main/java/br/gov/frameworkdemoiselle/util/Faces.java
@@ -180,4 +180,20 @@ public class Faces {
 		return getFacesContext().getViewRoot().getViewId();
 	}
 	
+	/**
+	 * Returns the application initialization parameter. This returns the
+	 * <code>&lt;param-value&gt;</code> of a <code>&lt;context-param&gt;</code> in
+	 * <code>web.xml</code> associated with the given
+	 * <code>&lt;param-name&gt;</code>.
+	 * 
+	 * @param name
+	 *            The application initialization parameter name.
+	 * @return The application initialization parameter value associated with the
+	 *         given name.
+	 * @see ExternalContext#getInitParameter(String)
+	 */
+	public static String getInitParameter(String name) {
+		return getFacesContext().getExternalContext().getInitParameter(name);
+	}
+
 }

--- a/impl/extension/jsf/src/main/resources/META-INF/faces-config.xml
+++ b/impl/extension/jsf/src/main/resources/META-INF/faces-config.xml
@@ -50,6 +50,12 @@
 			<var>messages</var>
 		</resource-bundle>
 
+		<system-event-listener>
+			<system-event-listener-class>br.gov.frameworkdemoiselle.internal.context.FacesViewContextEventListener</system-event-listener-class>
+			<system-event-class>javax.faces.event.PreDestroyViewMapEvent</system-event-class>
+			<source-class>javax.faces.component.UIViewRoot</source-class>
+		</system-event-listener>
+
 		<locale-config>
 			<default-locale>pt</default-locale>
 			<supported-locale>pt</supported-locale>

--- a/impl/extension/jsf/src/main/resources/demoiselle-jsf-bundle.properties
+++ b/impl/extension/jsf/src/main/resources/demoiselle-jsf-bundle.properties
@@ -41,3 +41,4 @@ after-logout-page-not-found=A tela "{0}" acessada ap\u00F3s o logout n\u00E3o fo
 faces-context-not-available=N\u00E3o existe uma inst\u00E2ncia de FacesContext ativa para esse escopo
 view-expired=A vis\u00E3o referenciada por essa tela expirou.
 faces-context-not-passivable=FacesContext n\u00E3o \u00E9 uma classe serializ\u00E1vel e n\u00E3o deve ser injetada em atributos de classes serializ\u00E1veis. Declare o atributo injetado como 'transient' (Atributo [{0}] na classe [{1}]).
+max-active-view-scopes-param-invalid=O par\u00E2metro de inicializa\u00E7\u00E3o {0} deve ser um n\u00FAmero. Foi encontrado um valor inv\u00E1lido: {1}.

--- a/impl/extension/jsf/src/test/java/test/Tests.java
+++ b/impl/extension/jsf/src/test/java/test/Tests.java
@@ -50,6 +50,7 @@ import br.gov.frameworkdemoiselle.annotation.Redirect;
 import br.gov.frameworkdemoiselle.internal.bootstrap.JsfBootstrap;
 import br.gov.frameworkdemoiselle.internal.configuration.ExceptionHandlerConfig;
 import br.gov.frameworkdemoiselle.internal.configuration.JsfSecurityConfig;
+import br.gov.frameworkdemoiselle.internal.context.FacesViewBeanStore;
 import br.gov.frameworkdemoiselle.internal.context.FacesViewContextImpl;
 import br.gov.frameworkdemoiselle.internal.implementation.AbstractExceptionHandler;
 import br.gov.frameworkdemoiselle.internal.implementation.ApplicationExceptionHandler;
@@ -125,6 +126,7 @@ public final class Tests {
 				.addClass(PreviousView.class)
 				.addClass(Redirect.class)
 				.addClass(NextView.class)
+				.addClass(FacesViewBeanStore.class)
 				.addAsResource(createFileAsset("src/main/resources/demoiselle-jsf-bundle.properties"),
 						"demoiselle-jsf-bundle.properties")
 				.addAsWebInfResource(createFileAsset("src/test/resources/test/beans.xml"), "beans.xml")


### PR DESCRIPTION
Isto serve para diminuir o uso de memória por beans que não são mais utilizados e que estão associados ao ViewScope. O número utilizado como padrão é 20. Porém, ele pode ser configurado através do web.xml. Implementação baseada na existente no OmniFaces.