### PR TITLE
Suporte a filtro de campos data e operadores relacionais.

### DIFF
--- a/demoiselle-crud/src/main/java/org/demoiselle/jee/crud/AbstractDAO.java
+++ b/demoiselle-crud/src/main/java/org/demoiselle/jee/crud/AbstractDAO.java
@@ -50,7 +50,12 @@ public abstract class AbstractDAO<T, I> implements Crud<T, I> {
 	/**
 	 * Formato da data/hora. ISO8601.
 	 */
-	private static final String ISO8601_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+	private static final String ISO8601_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSS";
+
+	/**
+	 * Formato da data/hora. ISO8601/UTC.
+	 */
+	private static final String ISO8601_UTC_PATTERN = ISO8601_PATTERN + "'Z'";
 
 	/**
 	 * Time zone padrão. UTC.
@@ -356,9 +361,12 @@ public abstract class AbstractDAO<T, I> implements Crud<T, I> {
 	}
 
 	protected Date convertStringToDate(String key, String value) {
-		final SimpleDateFormat formatter = new SimpleDateFormat(ISO8601_PATTERN);
+		final String pattern = getDatePattern(value);
+		final SimpleDateFormat formatter = new SimpleDateFormat(pattern);
 		//
-		formatter.setTimeZone(timeZoneUTC);
+		if (ISO8601_UTC_PATTERN.equals(pattern)) {
+			formatter.setTimeZone(timeZoneUTC);
+		}
 		//
 		try {
 			return formatter.parse(value);
@@ -377,12 +385,20 @@ public abstract class AbstractDAO<T, I> implements Crud<T, I> {
 
     protected boolean isDateFilter(String key, String value) {
     	try {
-			DateUtils.parseDate(value, ISO8601_PATTERN);
+			DateUtils.parseDate(value, getDatePattern(value));
 			//
 			return true;
 		} catch (final ParseException e) {
 			return false;
 		}
+    }
+
+    protected String getDatePattern(String date) {
+    	if (date.endsWith("Z")) {
+    		return ISO8601_UTC_PATTERN;
+    	} else {
+    		return ISO8601_PATTERN;
+    	}
     }
 
     protected Predicate buildLikePredicate(CriteriaBuilder criteriaBuilder, CriteriaQuery<?> criteriaQuery, From<?, ?> root, String key, String value) {

--- a/demoiselle-crud/src/main/java/org/demoiselle/jee/crud/CrudUtilHelper.java
+++ b/demoiselle-crud/src/main/java/org/demoiselle/jee/crud/CrudUtilHelper.java
@@ -54,8 +54,7 @@ public class CrudUtilHelper {
     public static void checkIfExistField(Class<?> targetClass, String field) {
         if (targetClass != null) {
             do {
-                List<Field> fields = new ArrayList<>();
-                getAllFields(fields, targetClass);
+                Field[] fields = targetClass.getDeclaredFields();
                 for (Field f : fields) {
                     if (f.getName().equalsIgnoreCase(field)) {
                         return;
@@ -66,36 +65,6 @@ public class CrudUtilHelper {
             throw new IllegalArgumentException();
         }
     }
-    
-    /**
-     * 
-     * Collect all fields from 'type' variable.
-     * 
-     * https://stackoverflow.com/questions/1042798/retrieving-the-inherited-attribute-names-values-using-java-reflection
-     * 
-     * @param fields
-     * @param type
-     * @return
-     */
-    public static List<Field> getAllFields(List<Field> fields, Class<?> type) {
-        fields.addAll(Arrays.asList(type.getDeclaredFields()));
-
-        if (type.getSuperclass() != null) {
-            getAllFields(fields, type.getSuperclass());
-        }
-
-        return fields;
-    }
-    
-    /**
-     * @param targetClass
-     * @param name
-     * @return
-     */
-    public static Field getField(Class<?> targetClass, String name) {
-        return getAllFields(new ArrayList<Field>(), targetClass).stream().filter( it -> it.getName().equals(name)).findAny().orElse(null);
-    }
-
 
     /**
      * Given a string like 'field1,field2(subField1,subField2)' this method will
@@ -347,7 +316,7 @@ public class CrudUtilHelper {
 
     public static String getMethodAnnotatedWithID(Class<?> targetClass) {    	
     	String name = null;
-    	for (Field field :  getAllFields(new ArrayList<Field>(), targetClass)) {
+    	for (Field field :  targetClass.getDeclaredFields() ) {
             if (field.isAnnotationPresent(Id.class)) {
             	name = field.getName();
             	break;

--- a/demoiselle-crud/src/main/java/org/demoiselle/jee/crud/CrudUtilHelper.java
+++ b/demoiselle-crud/src/main/java/org/demoiselle/jee/crud/CrudUtilHelper.java
@@ -54,7 +54,8 @@ public class CrudUtilHelper {
     public static void checkIfExistField(Class<?> targetClass, String field) {
         if (targetClass != null) {
             do {
-                Field[] fields = targetClass.getDeclaredFields();
+                List<Field> fields = new ArrayList<>();
+                getAllFields(fields, targetClass);
                 for (Field f : fields) {
                     if (f.getName().equalsIgnoreCase(field)) {
                         return;
@@ -65,6 +66,36 @@ public class CrudUtilHelper {
             throw new IllegalArgumentException();
         }
     }
+    
+    /**
+     * 
+     * Collect all fields from 'type' variable.
+     * 
+     * https://stackoverflow.com/questions/1042798/retrieving-the-inherited-attribute-names-values-using-java-reflection
+     * 
+     * @param fields
+     * @param type
+     * @return
+     */
+    public static List<Field> getAllFields(List<Field> fields, Class<?> type) {
+        fields.addAll(Arrays.asList(type.getDeclaredFields()));
+
+        if (type.getSuperclass() != null) {
+            getAllFields(fields, type.getSuperclass());
+        }
+
+        return fields;
+    }
+    
+    /**
+     * @param targetClass
+     * @param name
+     * @return
+     */
+    public static Field getField(Class<?> targetClass, String name) {
+        return getAllFields(new ArrayList<Field>(), targetClass).stream().filter( it -> it.getName().equals(name)).findAny().orElse(null);
+    }
+
 
     /**
      * Given a string like 'field1,field2(subField1,subField2)' this method will
@@ -316,7 +347,7 @@ public class CrudUtilHelper {
 
     public static String getMethodAnnotatedWithID(Class<?> targetClass) {    	
     	String name = null;
-    	for (Field field :  targetClass.getDeclaredFields() ) {
+    	for (Field field :  getAllFields(new ArrayList<Field>(), targetClass)) {
             if (field.isAnnotationPresent(Id.class)) {
             	name = field.getName();
             	break;

--- a/demoiselle-crud/src/main/java/org/demoiselle/jee/crud/CrudUtilHelper.java
+++ b/demoiselle-crud/src/main/java/org/demoiselle/jee/crud/CrudUtilHelper.java
@@ -307,7 +307,7 @@ public class CrudUtilHelper {
 
     }
 
-    private static Boolean hasSubField(String field) {
+    public static Boolean hasSubField(String field) {
         Pattern patternLevels = Pattern.compile("\\([^)]*\\)*");
         Matcher matcher = patternLevels.matcher(field);
 


### PR DESCRIPTION
**Filtro de Data**

Para filtrar consultas utilizando campos do tipo data, basta informar os valores dos parâmetros utilizando o padrão [ISO-8601](https://pt.wikipedia.org/wiki/ISO_8601) e no fuso [UTC](https://pt.wikipedia.org/wiki/Tempo_Universal_Coordenado). A conversão da data informada para o fuso do servidor é feita automaticamente, antes da consulta ser enviada ao banco de dados.

Exemplos:

- api/v1/usuarios?dataCadastro=**2017-11-28T12:40:02.000Z**

**Operadores Relacionais:**

Além do operador relacional **=**, os filtros agora também suportam os demais operadores, i.e., **>**, **<**, **>=** e **<=**.

Exemplos:

- api/v1/usuarios?idade=**>20**
- api/v1/usuarios?idade=**>=20**
- api/v1/usuarios?idade=**<18**
- api/v1/usuarios?idade=**<=18**

É possível combinar esses operadores, a fim de efetuar consultas por intervalo de valores:

- api/v1/usuarios?idade=**>18**&idade=**<21**
- api/v1/usuarios?dataCadastro=**>=2017-12-20T00:00:00.000Z**&dataCadastro=**<2017-12-21T00:00:00.000Z**