### PR TITLE
- Suporte a consulta por operadores relacionais (>,<,>=,<=)

### DIFF
--- a/demoiselle-crud/src/main/java/org/demoiselle/jee/crud/AbstractDAO.java
+++ b/demoiselle-crud/src/main/java/org/demoiselle/jee/crud/AbstractDAO.java
@@ -244,8 +244,6 @@ public abstract class AbstractDAO<T, I> implements Crud<T, I> {
         if (drc.getFilters() != null) {
             drc.getFilters().getChildren().stream().forEach(child -> {
 
-                List<Predicate> predicatesToBuild = new LinkedList<>();
-
                 /*
                  * If the child doesnt child the element is on fist level.
                  * 
@@ -253,11 +251,13 @@ public abstract class AbstractDAO<T, I> implements Crud<T, I> {
                  * 
                  */
                 if (child.getChildren().isEmpty()) {
+                	List<Predicate> predicatesToBuild = new LinkedList<>();
                     
                     child.getValue().stream().forEach(value -> {
                         fillPredicates(predicatesToBuild, root, criteriaBuilder, criteriaQuery, child, value, null);
                     });
                     
+                    predicates.add(criteriaBuilder.or(predicatesToBuild.toArray(new Predicate[]{})));
                 }
                 else{
 
@@ -269,14 +269,15 @@ public abstract class AbstractDAO<T, I> implements Crud<T, I> {
                     
                     Join<?, ?> join = root.join(child.getKey());
                     child.getChildren().stream().forEach( child2ndLevel -> {
+                    	List<Predicate> predicatesToBuild = new LinkedList<>();
 
                         child2ndLevel.getValue().stream().forEach(value -> {
                             fillPredicates(predicatesToBuild, join, criteriaBuilder, criteriaQuery, child2ndLevel, value, child);
                         });
+                        
+                        predicates.add(criteriaBuilder.or(predicatesToBuild.toArray(new Predicate[]{})));
                     });
                 } 
-                
-                predicates.add(criteriaBuilder.or(predicatesToBuild.toArray(new Predicate[]{})));
             });
         }
 

--- a/demoiselle-crud/src/main/java/org/demoiselle/jee/crud/CrudUtilHelper.java
+++ b/demoiselle-crud/src/main/java/org/demoiselle/jee/crud/CrudUtilHelper.java
@@ -338,7 +338,7 @@ public class CrudUtilHelper {
 
     }
 
-    private static Boolean hasSubField(String field) {
+    public static Boolean hasSubField(String field) {
         Pattern patternLevels = Pattern.compile("\\([^)]*\\)*");
         Matcher matcher = patternLevels.matcher(field);
 

--- a/demoiselle-crud/src/main/java/org/demoiselle/jee/crud/CrudUtilHelper.java
+++ b/demoiselle-crud/src/main/java/org/demoiselle/jee/crud/CrudUtilHelper.java
@@ -10,6 +10,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
@@ -315,7 +316,13 @@ public class CrudUtilHelper {
                     throw new IllegalArgumentException(crudMessage.fieldRequestDoesNotExistsOnObject(leaf.getKey(), targetClass.getName()));
                 }
 
-                Class<?> fieldClazz = fieldMaster.getType();
+                Class<?> fieldClazz;
+                
+                if (Collection.class.isAssignableFrom(fieldMaster.getType())) {
+                	fieldClazz = (Class<?>)((ParameterizedType)fieldMaster.getGenericType()).getActualTypeArguments()[0];
+                } else {
+                	fieldClazz = fieldMaster.getType();
+                }
 
                 leaf.getChildren().forEach((subLeaf) -> {
                     try {

--- a/demoiselle-crud/src/main/java/org/demoiselle/jee/crud/CrudUtilHelper.java
+++ b/demoiselle-crud/src/main/java/org/demoiselle/jee/crud/CrudUtilHelper.java
@@ -16,6 +16,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
 import javax.persistence.Id;
 
 import javax.ws.rs.container.ResourceInfo;
@@ -115,13 +117,26 @@ public class CrudUtilHelper {
         int lastComma = 0;
         int lastPosition = 0;
         String subField = "";
+        
+        int escapedCommas = 0;
 
         char fieldsArray[] = fields.toCharArray();
 
         for (int i = 0; i < fieldsArray.length; i++) {
 
             char letter = fieldsArray[i];
-
+            char nextLetter = i + 1 < fieldsArray.length ? fieldsArray[i + 1] : Character.MIN_VALUE;
+            
+            if (letter == ',') {
+            	if (nextLetter == ',' && escapedCommas == 0) {
+            		escapedCommas++;
+            		continue;
+            	} else if (escapedCommas > 0) {
+            		escapedCommas = 0;
+            		continue;
+            	}
+            }
+            
             // Find util the next ',' character
             if (letter == ',') {
                 lastComma = i;
@@ -178,7 +193,7 @@ public class CrudUtilHelper {
             results.add(subField);
         }
 
-        return results;
+        return results.stream().map(s -> s.replace(",,", ",")).collect(Collectors.toList());
     }
     
     /**


### PR DESCRIPTION
**Operadores Relacionais:**

Além do operador relacional **=**, os filtros agora também suportam os demais operadores, i.e., **>**, **<**, **>=** e **<=**.

Exemplos:

- api/v1/usuarios?idade=**>20**
- api/v1/usuarios?idade=**>=20**
- api/v1/usuarios?idade=**<18**
- api/v1/usuarios?idade=**<=18**

É possível combinar esses operadores, a fim de efetuar consultas por intervalo de valores:

- api/v1/usuarios?idade=**>18**&idade=**<21**
- api/v1/usuarios?dataCadastro=**>=2017-12-20T00:00:00.000Z**&dataCadastro=**<2017-12-21T00:00:00.000Z**

**Filtro de Data**

Para filtrar consultas utilizando campos do tipo data, basta informar os valores dos parâmetros utilizando o padrão [ISO-8601](https://pt.wikipedia.org/wiki/ISO_8601) e no fuso [UTC](https://pt.wikipedia.org/wiki/Tempo_Universal_Coordenado). A conversão da data informada para o fuso do servidor é feita automaticamente, antes da consulta ser enviada ao banco de dados.

Exemplos:

- api/v1/usuarios?dataCadastro=**2017-11-28T12:40:02.000Z**

Adicionei também o suporte a datas sem fuso, as quais não serão ajustadas para o fuso do servidor. 

Esta alteração é útil quando campos desse tipo ignorarem a informação da hora, como acontece em muitas situações.

Então ao enviar a data sem o Z no final, o qual indica que a presença do fuso UTC, a mesma será utilizada da forma como foi enviada, sem nenhum ajuste de fuso.

Exemplo:

- api/v1/usuarios?dataNascimento=**2017-11-28T00:00:00.000**

**Ordenação em Campos de Segundo Nível**

Exemplos:

- api/v1/usuarios?sort=**perfil(nome)**
- api/v1/usuarios?sort=**perfil(nome)**&desc